### PR TITLE
Fix small typo in Transition card

### DIFF
--- a/index.html
+++ b/index.html
@@ -415,7 +415,7 @@
 				</div>
 				<div class="card-content left">
 					<label for="checkbox24">Transitions</label>
-					<p>Motion shouldn't be only beautiful, it have to builds meaning about the spatial relationships, functionality, and intention of the system. <a class="more hide-for-print" href="http://www.google.co.uk/design/spec/animation/authentic-motion.html" target="_blank" title="Material Design Authentic motion">Read more</a></p>
+					<p>Motion shouldn't be only beautiful, it should build meaning about the spatial relationships, functionality, and intention of the system. <a class="more hide-for-print" href="http://www.google.co.uk/design/spec/animation/authentic-motion.html" target="_blank" title="Material Design Authentic motion">Read more</a></p>
 					<!-- http://www.smashingmagazine.com/2013/10/23/smart-transitions-in-user-experience-design/ -->
 					<!-- http://www.smashingmagazine.com/2012/02/28/mission-transition/ -->
 				</div>


### PR DESCRIPTION
There was a small grammatical error in the transitions card, changed to reflect the same text as the readme file.