### PR TITLE
usability checklist inspiration link moved

### DIFF
--- a/index.html
+++ b/index.html
@@ -507,7 +507,7 @@
 			<a href="https://twitter.com/alefranz" target="_blank" title="@alefranz">@alefranz</a> for the technical magic.</br>
 			</p>
 			<p>
-			Inspired by&nbsp;<a href="http://webdesignerschecklist.com/" target="_blank" title="webdesignerschecklist">this</a>,&nbsp;<a href="https://userium.com/" target="_blank" title="Usability checklist">this</a>&nbsp;and&nbsp;<a href="http://ixdchecklist.com/" target="_blank" title="ixdchecklist">this</a>
+			Inspired by&nbsp;<a href="http://webdesignerschecklist.com/" target="_blank" title="webdesignerschecklist">this</a>,&nbsp;<a href="https://stayintech.com/info/UX" target="_blank" title="Usability checklist">this</a>&nbsp;and&nbsp;<a href="http://ixdchecklist.com/" target="_blank" title="ixdchecklist">this</a>
 			</p>
 			<p>
 			Also thanks to:</br>


### PR DESCRIPTION
Hello!
Just noticed that in the "Friends of this page" section at the bottom of the page, the link to the "Usability checklist" has been moved.

So i corrected it:
https://usarium.com -> https://stayintech.com/info/UX

Have a nice day!