### PR TITLE
Bugfix/drive sync cache

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -83,7 +83,7 @@ gulp.task('deploy', function () {
 });
 
 gulp.task('js', function() {
-  gulp.src('js/*.js')
+  gulp.src(['js/polyfill/*,js', 'js/*.js'])
     .pipe(uglify())
     .pipe(size({ gzip: true, showFiles: true }))
     .pipe(concat('j.js'))
@@ -110,14 +110,14 @@ gulp.task('minify-html', function() {
 });
 
 gulp.task('jshint', function() {
-  gulp.src('js/*.js')
+  gulp.src(['js/polyfill/*,js', 'js/*.js'])
     .pipe(jshint())
     .pipe(jshint.reporter('default'));
 });
 
 gulp.task('watch', function() {
   gulp.watch('scss/**/*.scss', ['scss']);
-  gulp.watch('js/*.js', ['jshint', 'js']);
+  gulp.watch(['js/polyfill/*,js', 'js/*.js'], ['jshint', 'js']);
   gulp.watch('./*.html', ['minify-html']);
   gulp.watch('img/**/*', ['imgmin']);
 });

--- a/js/index.js
+++ b/js/index.js
@@ -88,9 +88,9 @@ var renameProject = function(newTitle) {
 
 $().ready(function() {
     var setTitles = function(titles, selectedTitle, fileId, e) {
-        log(titles);
-        log(selectedTitle);
-        log(fileId);
+        //log(titles);
+        //log(selectedTitle);
+        //log(fileId);
         var newTitle = defaultTitle;
         var titleCounter = 0;
         var titleTest = function(title, _) {
@@ -99,7 +99,7 @@ $().ready(function() {
         while (titles.some(titleTest)) {
             newTitle = defaultTitle + (++titleCounter);
         }
-        log(newTitle);
+        //log(newTitle);
         $("#project h1").text(selectedTitle);
         $(e).empty();
         $(titles).each(function(_, title) {
@@ -125,7 +125,7 @@ $().ready(function() {
             shareClient.setItemIds([fileId]);
             $('#file-share').on('click', function() {
                 ga('send', 'event', 'share', 'click', 'share');
-                shareClient.showSettingsDialog();
+                shareClient.showSettingsDia//log();
             });
         });
     }
@@ -189,7 +189,7 @@ $().ready(function() {
         return $(e).is(':checked');
     };
     var setFn = function(id, e, val) {
-        log("setting " + e.id + " as " + val);
+        //console.log('setting', e.id, val);
         $(e).prop('checked', val);
     };
     $('input:checkbox').each(function() {
@@ -198,7 +198,7 @@ $().ready(function() {
     });
     view = new Realtime.View(fileList, checkboxes);
     var cb = view.checkboxes;
-    log(cb);
+    //log(cb);
     controller = new Realtime.Controller(view);
 
     var getParam = function(name) {
@@ -207,19 +207,19 @@ $().ready(function() {
     };
 
     var title = getParam('title');
-    log(title);
+    //log(title);
     if (title) {
         ga('send', 'event', 'file', 'open_by_title', 'file');
     }
     var ids = getParam('ids');
-    log(ids);
+    //log(ids);
     if (ids) {
         ga('send', 'event', 'file', 'open_by_id', 'file');
     }
     gapi.load("auth:client,drive-share", function() {
         controller.init();
         $('form').on('change', 'input:checkbox', function(ev) {
-            log(ev);
+            //log(ev);
             if (controller.isLoaded()) {
                 controller.onCheckBoxChange($(ev.target).attr('id'));
             }
@@ -243,7 +243,7 @@ $().ready(function() {
             $('#header').removeClass('loading');
             $("#checklist-form").garlic();
             useGarlic = true;
-            log("Local storage enabled");
+            //log("Local storage enabled");
         };
 
         controller.auth(true,
@@ -254,7 +254,7 @@ $().ready(function() {
                 $('#header').removeClass('loading');
                 $("#checklist-form").garlic();
                 useGarlic = true;
-                log("Local storage enabled");
+                //log("Local storage enabled");
             },
             title,
             ids,

--- a/js/polyfill/object.assign.js
+++ b/js/polyfill/object.assign.js
@@ -1,0 +1,29 @@
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, "assign", {
+    value: function assign(target, varArgs) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}

--- a/js/realtime.js
+++ b/js/realtime.js
@@ -25,13 +25,9 @@ Realtime.Controller.prototype.isLoaded = function() {
   return this.uxchecklist != null;
 };
 
-Realtime.Controller.prototype.loaded = function(result) {
-  console.log('Realtime.loaded invoke', result);
-  
+Realtime.Controller.prototype.loaded = function(result) {  
   var model = result.properties;
   this.uxchecklist = model || [];
-  
-  console.log('Realtime.loaded model', this.uxchecklist, model);
 
   var self = this;
 
@@ -46,9 +42,6 @@ Realtime.Controller.prototype.loaded = function(result) {
   });
 
   var mergedData = Object.assign({}, resetData, syncData);
-
-  console.log('Merge data mapped:', mergedData);
-  console.log('Sync data mapped:', syncData);
 
   Object.keys(mergedData).map(function (x) {
     self.view.checkboxes[x].setChecked(mergedData[x]);


### PR DESCRIPTION
Fixes Google Drive sync cache on `realtime.js` while using the `index-multi.html` version of the checklist.
Compares the file `version` (apparently it's the revision version) between the "cached" response from Google Drive with the current file list already fetched. 

Steps to replicate the bug in the current `drive-realtime-deprecation` branch:

- Create a new project
- Rename it "project1"
- Tick some boxes
- Create a new project from the sidebar
- Rename it "project2"
- Tick some boxes
- Switch back to "project1", everything should work
- Switch back to "project2", now the "project2" doesn't have any boxes checked.

@sovesove good if you can try on your end with Safari as I don't have that on my Linux